### PR TITLE
Added grunt-concurrent to the livereload task

### DIFF
--- a/grunt/tasks/livereload.task.js
+++ b/grunt/tasks/livereload.task.js
@@ -32,10 +32,32 @@ module.exports = function (grunt, taskConfigs) {
         }
     };
 
+    /**
+     * Pull out watch tasks to register with grunt-concurrent
+     * @author JOV
+     */
+    let concurrentTasks = [];
+    for (let task in taskConfigs.watch) {
+        if (task !== "options") {
+            concurrentTasks.push("watch:" + task);
+        }
+    }
+
+    //Add concurrent config to the taskConfigs object
+    taskConfigs.concurrent = {
+        watch: {
+            options: {
+                limit: concurrentTasks.length,
+                logConcurrentOutput: true
+            },
+            tasks: concurrentTasks
+        }
+    };
+
     //Register livereload-enabled watch-task.
     grunt.registerTask("livereload", () => {
         enableWrapper();
-        grunt.task.run(["watch"]);
+        grunt.task.run(["concurrent:watch"]);
     });
 
     //Register task to allow other tasks to modify wrapper on build (i.e. ensure file exists to avoid 404 in browser).

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "autoprefixer": "^6.6.1",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
+    "grunt-concurrent": "^2.3.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-uglify": "^2.0.0",


### PR DESCRIPTION
This change will allow all watch tasks to be run by "grunt-concurrent". It features a faster compilation time and also seems to reduce the load on file watchers; Once in a while I experience a complete halt of the watch task and I have to restart it to continue. It seems, by using grunt-concurrent, that this issue is gone.

I have not heard of anyone else experiencing this problem, but maybe grunt-concurrent will be good to have anyway. What do you think?